### PR TITLE
Installer fixes and features

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,9 +1,8 @@
 name: Push Installer to s3
 
 on:
-  push:
-    branches:
-      - karan_installer # Placeholder for now, should activate on release in femr repo
+  repository_dispatch:
+    types: [generate-installer]
 
 jobs:
   release:
@@ -18,12 +17,12 @@ jobs:
           python-version: "3.10"
           cache: "pip"
       - run: pip install -r requirements.txt
-      - run: python release.py --version 3.0.0
+      - run: python release.py --version ${{ github.event.client_payload.version }}
 
       - name: Check if an installer file is present
         run: |
           if [ -n "$(ls -A macOS-x64/target/pkg/ 2>/dev/null)" ]; then 
-            echo "Installer is present"; 
+            echo "Installer successfully generated. Check s3 bucket to verify."; 
           else 
-            echo "Installer is missing" && exit 1; 
+            echo "Installer is missing." && exit 1; 
           fi

--- a/macOS-x64/application/docker-compose.yml
+++ b/macOS-x64/application/docker-compose.yml
@@ -16,6 +16,12 @@ services:
       - "3306"
     volumes:
       - db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
+      interval: 30s
+      retries: 3
+      start_period: 10s
+      timeout: 5s
 
   femr:
     platform: linux/arm64/v8

--- a/macOS-x64/build-macos-x64.sh
+++ b/macOS-x64/build-macos-x64.sh
@@ -147,8 +147,8 @@ copyBuildDirectory() {
     chmod -R 755 "${TARGET_DIRECTORY}"/darwinpkg/Library/${PRODUCT}/${VERSION}
     
     #Changes the script dir variable to the target path. This used to start the docker compose later.
-    sed -i -e 's#__SCRIPT_DIR__#'${TARGET_DIRECTORY}'/darwinpkg/Library/'${PRODUCT}'/'${VERSION}'#g' "${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}/start-femr"
-    
+    sed -i -e 's#__SCRIPT_DIR__#''/var/'${PRODUCT}'#g' "${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}/start-femr"
+
     rm -rf "${TARGET_DIRECTORY}/package"
     mkdir -p "${TARGET_DIRECTORY}/package"
     chmod -R 755 "${TARGET_DIRECTORY}/package"

--- a/macOS-x64/build-macos-x64.sh
+++ b/macOS-x64/build-macos-x64.sh
@@ -146,7 +146,7 @@ copyBuildDirectory() {
     cp -a "$SCRIPTPATH"/application/. "${TARGET_DIRECTORY}"/darwinpkg/Library/${PRODUCT}/${VERSION}
     chmod -R 755 "${TARGET_DIRECTORY}"/darwinpkg/Library/${PRODUCT}/${VERSION}
     
-    #Changes the script dir variable to the target path. This used to start the docker compose later.
+    #Sets the script_dir variable that's located in the postinstall script.
     sed -i -e 's#__SCRIPT_DIR__#''/var/'${PRODUCT}'#g' "${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}/start-femr"
 
     rm -rf "${TARGET_DIRECTORY}/package"

--- a/release.py
+++ b/release.py
@@ -18,17 +18,14 @@ def main():
 
     s3 = boto3.client('s3')
 
-    # Print the output of 'ls' command
-    subprocess.run(['ls', './macOS-x64/target/pkg'], check=True)
-    '''
+    print('Uploading macOS installer to S3. This may take a while...')
+
     s3.upload_file(
         f'./macOS-x64/target/pkg/femr-macos-installer-x64-{args.version}.pkg', 
         BUCKET_NAME, 
-        f'{args.version}/femr-x64-{args.version}.pkg'
+        f'macos/{args.version}/femr-x64-{args.version}.pkg'
     )
-    '''
 
-    
 if __name__ == "__main__":
     main()
 


### PR DESCRIPTION
Fixes:
- Fixed bug that made installer use absolute path of the person who generated the installer. Set it to use var/femr instead which is where the installer stores the files.
- Added a healthcheck to the SQL database to fix the docker error which caused the app to close and need to be manually ran from dockerhub.
- Made s3 upload specify platform to align with how the fibula app pulls the installer files.

Features:
- Set workflow to run on dispatch with type generate-installer.